### PR TITLE
Correct get params

### DIFF
--- a/appnexusapi.gemspec
+++ b/appnexusapi.gemspec
@@ -19,3 +19,4 @@ Gem::Specification.new do |gem|
   gem.add_dependency  "multi_json", "~> 1.10.1"
   gem.add_development_dependency 'bundler', '>= 1.2.0'
 end
+end

--- a/appnexusapi.gemspec
+++ b/appnexusapi.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.version       = AppnexusApi::VERSION
 
   gem.add_dependency 'faraday', '~>0.8.7'
-  gem.add_dependency  "multi_json", "~> 1.7.2"
+  gem.add_dependency  "multi_json", "~> 1.10.1"
   gem.add_development_dependency 'bundler', '>= 1.2.0'
 end

--- a/lib/appnexusapi/service.rb
+++ b/lib/appnexusapi/service.rb
@@ -36,10 +36,10 @@ class AppnexusApi::Service
 
   def get(params={})
     return_response = params.delete(:return_response) || false
-    params = {
-      "num_elements" => 100,
-      "start_element" => 0
-    }.merge(params)
+    # params = {
+    #   "num_elements" => 100,
+    #   "start_element" => 0
+    # }.merge(params)
     response = @connection.get(uri_suffix, params)
     if return_response
       response

--- a/lib/appnexusapi/service.rb
+++ b/lib/appnexusapi/service.rb
@@ -37,7 +37,7 @@ class AppnexusApi::Service
   def get(params={})
     return_response = params.delete(:return_response) || false
     params = {
-      "num_elements" => 200,
+      "num_elements" => 100,
       "start_element" => 0
     }.merge(params)
     response = @connection.get(uri_suffix, params)

--- a/lib/appnexusapi/service.rb
+++ b/lib/appnexusapi/service.rb
@@ -37,7 +37,7 @@ class AppnexusApi::Service
   def get(params={})
     return_response = params.delete(:return_response) || false
     params = {
-      "num_elements" => 100,
+      "num_elements" => 200,
       "start_element" => 0
     }.merge(params)
     response = @connection.get(uri_suffix, params)

--- a/lib/appnexusapi/service.rb
+++ b/lib/appnexusapi/service.rb
@@ -36,10 +36,10 @@ class AppnexusApi::Service
 
   def get(params={})
     return_response = params.delete(:return_response) || false
-    # params = {
-    #   "num_elements" => 100,
-    #   "start_element" => 0
-    # }.merge(params)
+    
+    params["num_elements"] = 100 if params["num_elements"].nil?
+    params["start_element"] = 0 if params["start_element"].nil?
+
     response = @connection.get(uri_suffix, params)
     if return_response
       response

--- a/lib/appnexusapi/version.rb
+++ b/lib/appnexusapi/version.rb
@@ -1,3 +1,3 @@
 module AppnexusApi
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end


### PR DESCRIPTION
Params hash would always use the default params and discarded the values that where passed. The changes ensures the correct parameters are used. 