### PR TITLE
Deal with appnexus not retracting checksums correctly

### DIFF
--- a/lib/appnexusapi/log_level_data_resource.rb
+++ b/lib/appnexusapi/log_level_data_resource.rb
@@ -4,7 +4,7 @@ class AppnexusApi::LogLevelDataResource < AppnexusApi::Resource
     fail 'Missing necessaray information!' unless name && hour && timestamp && splits
 
     splits.map do |split_part|
-      # In the case of regenerated files, there can be no checksum.  These replaced hourly files should not be downloaded.
+      # In the case of regenerated files, there should be no checksum.  These replaced hourly files should not be downloaded.
       next nil if split_part['checksum'].blank?
 
       {

--- a/lib/appnexusapi/log_level_data_resource.rb
+++ b/lib/appnexusapi/log_level_data_resource.rb
@@ -2,19 +2,18 @@ class AppnexusApi::LogLevelDataResource < AppnexusApi::Resource
   # Extract an array of hashes of params to pass to the LogLevelDownloadService
   def download_params
     fail 'Missing necessaray information!' unless name && hour && timestamp && splits
+
     splits.map do |split_part|
-      if split_part['checksum'].blank?
-        # In the case of regenerated files, there can be no checksum.  These replaced hourly files should not be downloaded.
-        nil
-      else
-        {
-          split_part: split_part['part'],
-          siphon_name: name,
-          timestamp: timestamp,
-          hour: hour,
-          checksum: split_part['checksum']
-        }
-      end
+      # In the case of regenerated files, there can be no checksum.  These replaced hourly files should not be downloaded.
+      next nil if split_part['checksum'].blank?
+
+      {
+        split_part: split_part['part'],
+        siphon_name: name,
+        timestamp: timestamp,
+        hour: hour,
+        checksum: split_part['checksum']
+      }
     end.compact
   end
 end

--- a/lib/appnexusapi/log_level_data_service.rb
+++ b/lib/appnexusapi/log_level_data_service.rb
@@ -11,7 +11,13 @@ class AppnexusApi::LogLevelDataService < AppnexusApi::Service
     params[:siphon_name] = @siphon_name if @siphon_name
     params[:updated_since] = time.strftime('%Y_%m_%d_%H') if time
 
-    get(params)
+    # Anything with the same name and hour but with a newer timestamp is a republished replacement for an older file
+    # When this happens appnexus is supposed to set the checksum for the old file to null but they do not always
+    # actually do this.
+    siphons = get(params)
+    siphons.reject do |siphon|
+      (siphons - [siphon]).any? { |s| s.name == siphon.name && s.hour == siphon.hour && s.timestamp > siphon.timestamp }
+    end
   end
 
   def uri_name


### PR DESCRIPTION
@joshuawscott @rfroetscher

Appnexus docs suddenly have this suspcious parenthetical statement that didn't used to be there about whether checksums will be correctly retracted for replaced log files.

> You may see that the old file does not have any checksums generated (sometimes the old file can also have checksums); this is normal and is expected. The new file will be a corrected version of the original file instead of just the difference between the two. When you pull new files, please therefore be sure to look back three days for any regenerations.