### PR TITLE
Contend with rate limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.env
+log

--- a/README.md
+++ b/README.md
@@ -51,16 +51,6 @@ Use a Service:
     creative = creative_service.create(new_creative)
     creative.update("campaign" => "Testing")
 
-## Debugging
-
-The APPNEXUS_API_DEBUG environment variable will trigger full printouts of Faraday's debug output to STDERR.
-
-```bash
-cd /my/app
-export APPNEXUS_API_DEBUG=true
-bundle exec rails whatever
-```
-
 ## Testing
 
 There is a rudimentary test suite that centers around creatives/creative_service.  To use it, you'll need to copy the `env_example` file to `.env` and replace the values with your correct values for your account. After that, a simple `bundle exec rspec spec` will run the test suite

--- a/README.md
+++ b/README.md
@@ -22,11 +22,14 @@ Establish a connection:
 
     connection = AppnexusApi::Connection.new(
       'username' => 'username',
-      'password' => 'password'
+      'password' => 'password',
+      'logger'   => Logger.new(STDOUT) # defaults to a null logger if no value passed in.
 
       # Defaults to connecting to https://api.appnexus.com/ but you can optionally pass a uri to
       # connect to another endpoint, e.g. the staging site could be
-      # uri: 'http://api.sand-08.adnxs.net'
+      # uri: 'http://api.sand-08.adnxs.net
+
+      
     )
 
 Use a Service:

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Use a Service:
     creative_service = AppnexusApi::CreativeService.new(connection, member.id)
 
     new_creative = {
-      "media_url" => "http://ad.doubleclick.net/adi/ABC.Advertising.com/DEF.40;sz=300x250;click0=",
+      "content"   => "<iframe src='helloword.html'></iframe>",
       "width" => "300",
       "height" => "250",
-      "format" => "url-html"
+      "template"  =>{ "id" => 7 }
     }
     creative = creative_service.create(new_creative)
     creative.update("campaign" => "Testing")
@@ -57,6 +57,11 @@ cd /my/app
 export APPNEXUS_API_DEBUG=true
 bundle exec rails whatever
 ```
+
+## Testing
+
+There is a rudimentary test suite that centers around creatives/creative_service.  To use it, you'll need to copy the `env_example` file to `.env` and replace the values with your correct values for your account. After that, a simple `bundle exec rspec spec` will run the test suite
+
 
 ## Contributing
 

--- a/appnexusapi.gemspec
+++ b/appnexusapi.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'faraday_middleware'
   gem.add_dependency 'multi_json'
   gem.add_dependency 'pester'
-  
+  gem.add_dependency 'null_logger'
+
   gem.add_development_dependency 'bundler', '>= 1.2.0'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'dotenv'

--- a/appnexusapi.gemspec
+++ b/appnexusapi.gemspec
@@ -21,4 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'pester'
   
   gem.add_development_dependency 'bundler', '>= 1.2.0'
+  gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'dotenv'
+  gem.add_development_dependency 'pry'
 end

--- a/env_example
+++ b/env_example
@@ -1,0 +1,5 @@
+APPNEXUS_MEMBER_ID=123
+APPNEXUS_USERNAME=appnexus_user
+APPNEXUS_PASSWORD=HGsgwDdxDVWM
+APPNEXUS_URI=https://sand.api.adnxs.com
+

--- a/lib/appnexusapi/connection.rb
+++ b/lib/appnexusapi/connection.rb
@@ -3,6 +3,7 @@ require 'appnexusapi/faraday/raise_http_error'
 
 class AppnexusApi::Connection
   RATE_EXCEEDED_TIMEOUT = 5
+  RATE_EXCEEDED_CODE = "RATE_EXCEEDED"
 
   def initialize(config)
     @config = config
@@ -58,7 +59,7 @@ class AppnexusApi::Connection
     begin
       while true
         response = @connection.run_request(method, route, body, { 'Authorization' => @token }.merge(headers))
-        break unless response.body["response"]["error_code"] == "RATE_EXCEEDED"
+        break unless response.body["response"]["error_code"] == RATE_EXCEEDED_CODE
         sleep RATE_EXCEEDED_TIMEOUT
       end
     rescue AppnexusApi::Unauthorized => e

--- a/lib/appnexusapi/connection.rb
+++ b/lib/appnexusapi/connection.rb
@@ -60,8 +60,13 @@ class AppnexusApi::Connection
     login if !is_authorized?
     response = {}
     begin
-      while true
-        response = @connection.run_request(method, route, body, { 'Authorization' => @token }.merge(headers))
+      loop do
+        response = @connection.run_request(
+          method,
+          route,
+          body,
+          { 'Authorization' => @token }.merge(headers)
+        )
         break unless response.status == RATE_EXCEEDED_HTTP_CODE
         wait_time = response.headers['retry-after'] || RATE_EXCEEDED_DEFAULT_TIMEOUT
         log.info("received rate exceeded.  wait time: #{wait_time}s")
@@ -75,7 +80,7 @@ class AppnexusApi::Connection
         logout
         run_request(method, route, body, headers)
       end
-    rescue Faraday::Error::TimeoutError => e
+    rescue Faraday::Error::TimeoutError => _e
       raise AppnexusApi::Timeout, 'Timeout'
     ensure
       @retry = false

--- a/lib/appnexusapi/error.rb
+++ b/lib/appnexusapi/error.rb
@@ -12,5 +12,4 @@ module AppnexusApi
   class ServiceUnavailable < Error; end
   class InvalidJson < Error; end
   class Timeout < Error; end
-  class RateExceeded < Error; end
 end

--- a/lib/appnexusapi/error.rb
+++ b/lib/appnexusapi/error.rb
@@ -12,4 +12,5 @@ module AppnexusApi
   class ServiceUnavailable < Error; end
   class InvalidJson < Error; end
   class Timeout < Error; end
+  class RateExceeded < Error; end
 end

--- a/lib/appnexusapi/resource.rb
+++ b/lib/appnexusapi/resource.rb
@@ -1,5 +1,7 @@
 class AppnexusApi::Resource
 
+  attr_reader :dbg_info
+
   def initialize(json, service, dbg_info = nil)
     @json = json
     @service = service
@@ -17,10 +19,6 @@ class AppnexusApi::Resource
 
   def raw_json
     @json
-  end
-
-  def dbg_info
-    @dbg_info
   end
 
   def method_missing(sym, *args, &block)

--- a/lib/appnexusapi/resource.rb
+++ b/lib/appnexusapi/resource.rb
@@ -1,8 +1,9 @@
 class AppnexusApi::Resource
 
-  def initialize(json, service)
+  def initialize(json, service, dbg_info = nil)
     @json = json
     @service = service
+    @dbg_info = dbg_info
   end
 
   def update(attributes={})
@@ -16,6 +17,10 @@ class AppnexusApi::Resource
 
   def raw_json
     @json
+  end
+
+  def dbg_info
+    @dbg_info
   end
 
   def method_missing(sym, *args, &block)

--- a/lib/appnexusapi/service.rb
+++ b/lib/appnexusapi/service.rb
@@ -56,7 +56,6 @@ class AppnexusApi::Service
     while last_responses.size > 0
       responses += last_responses
       last_responses = get(params.merge('start_element' => responses.size))
-      sleep(1) # The gem has no error handling at all for rate limit errors; sleeping for a second prevents errors
     end
 
     responses

--- a/lib/appnexusapi/service.rb
+++ b/lib/appnexusapi/service.rb
@@ -89,15 +89,18 @@ class AppnexusApi::Service
   end
 
   def parse_response(response)
-    if response.has_key?(plural_name) || response.has_key?(plural_uri_name)
-      key = response.has_key?(plural_name) ? plural_name : plural_uri_name
+    case key = resource_name(response)
+    when plural_name, plural_uri_name
       response[key].map do |json|
         resource_class.new(json, self, response['dbg'])
       end
-    elsif response.has_key?(name) || response.has_key?(uri_name)
-      key = response.has_key?(name) ? name : uri_name
+    when name, uri_name
       [resource_class.new(response[key], self, response['dbg'])]
     end
+  end
+
+  def resource_name(response)
+    [plural_name, plural_uri_name, name, uri_name].detect { |n| response.key?(n) }
   end
 
 end

--- a/lib/appnexusapi/version.rb
+++ b/lib/appnexusapi/version.rb
@@ -1,3 +1,3 @@
 module AppnexusApi
-  VERSION = "0.0.9"
+  VERSION = "0.0.10"
 end

--- a/lib/appnexusapi/version.rb
+++ b/lib/appnexusapi/version.rb
@@ -1,3 +1,3 @@
 module AppnexusApi
-  VERSION = "0.1.0"
+  VERSION = '0.1.0'.freeze
 end

--- a/lib/appnexusapi/version.rb
+++ b/lib/appnexusapi/version.rb
@@ -1,3 +1,3 @@
 module AppnexusApi
-  VERSION = "0.0.10"
+  VERSION = "0.1.0"
 end

--- a/spec/creative_service_spec.rb
+++ b/spec/creative_service_spec.rb
@@ -1,25 +1,27 @@
 require 'spec_helper'
 
 describe AppnexusApi::CreativeService do
-
-  let(:creative_service) { AppnexusApi::CreativeService.new(connection, ENV['APPNEXUS_MEMBER_ID']) }
-  let(:new_creative) {
+  let(:creative_service) do
+    AppnexusApi::CreativeService.new(connection, ENV['APPNEXUS_MEMBER_ID'])
+  end
+  let(:new_creative) do
     {
-      "campaign"  => "default campaign",
-      "content"   => "<iframe src='helloword.html'></iframe>",
-      "width"     => "300",
-      "height"    => "250",
-      "template"  =>{ "id" => 7 }
+      'campaign'  => 'default campaign',
+      'content'   => '<iframe src="helloword.html"></iframe>',
+      'width'     => '300',
+      'height'    => '250',
+      'template'  => { 'id' => 7 }
     }
-  }
+  end
 
-  it 'respects the throttle limit' do
-    # this spec will attempt to make 100 writes as fast as possible with 10 threads running in a loop
-    # of 10.  Typically you hit the limit right around 25 seconds in.  If your connection is slow, this
+  it 'respects the throttle limit', slow: true do
+    # this spec will attempt to make 100 writes as fast as possible with 10
+    # threads running in a loop of 10.  Typically you hit the limit right
+    # around 25 seconds in.  If your connection is slow, this
     # test may never hit the throttle limit
     expect do
       # this runs so we only authenticate once instead of 10 times.
-      _prime_the_pump = creative_service.get('num_elements' => 1, 'start_element' => 0)
+      _p = creative_service.get('num_elements' => 1, 'start_element' => 0)
       10.times do
         threads = []
         10.times do
@@ -34,12 +36,12 @@ describe AppnexusApi::CreativeService do
   end
 
   it 'supports a get operation' do
-    expect {
-      creative_service.get("start_element" => 0, "num_elements" => 1)
-    }.to_not raise_error
+    expect do
+      creative_service.get('start_element' => 0, 'num_elements' => 1)
+    end.to_not raise_error
   end
 
-  context "creating a new creative" do
+  context 'creating a new creative' do
     it 'supports creating a new creative' do
       creative = creative_service.create(new_creative)
       expect(creative.width).to eq 300
@@ -47,21 +49,21 @@ describe AppnexusApi::CreativeService do
     end
   end
 
-  context "an existing creative" do
+  context 'an existing creative' do
     let(:existing_creative) { creative_service.create(new_creative) }
 
     it 'supports changing attributes with the update action' do
-      expect(existing_creative.campaign).to eq "default campaign"
-      existing_creative.update("campaign" => "My Best Campaign Yet")
-      expect(existing_creative.campaign).to eq "My Best Campaign Yet"
+      expect(existing_creative.campaign).to eq 'default campaign'
+      existing_creative.update('campaign' => 'My Best Campaign Yet')
+      expect(existing_creative.campaign).to eq 'My Best Campaign Yet'
     end
 
     it 'supports removing the creative' do
       id = existing_creative.id
-      creative = creative_service.get("id" => id).first
+      creative = creative_service.get('id' => id).first
       expect(creative.id).to eq id
       existing_creative.delete
-      creative = creative_service.get("id" => id)
+      creative = creative_service.get('id' => id)
       expect(creative).to be_nil
     end
   end

--- a/spec/creative_service_spec.rb
+++ b/spec/creative_service_spec.rb
@@ -13,11 +13,13 @@ describe AppnexusApi::CreativeService do
     }
   }
 
-  xit 'respects the throttle limit' do
-    # this spec is purposefully disabled as it will create 100 new creatives as fast as possbile to bump up against
-    # the write limits.  Run this spec at your own peril!  Also, running this spec more than once in a row will
-    # bump up against your authorization limit of 10 per 300 seconds
+  it 'respects the throttle limit' do
+    # this spec will attempt to make 100 writes as fast as possible with 10 threads running in a loop
+    # of 10.  Typically you hit the limit right around 25 seconds in.  If your connection is slow, this
+    # test may never hit the throttle limit
     expect do
+      # this runs so we only authenticate once instead of 10 times.
+      _prime_the_pump = creative_service.get('num_elements' => 1, 'start_element' => 0)
       10.times do
         threads = []
         10.times do

--- a/spec/creative_service_spec.rb
+++ b/spec/creative_service_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe AppnexusApi::CreativeService do
+
+  let(:creative_service) { AppnexusApi::CreativeService.new(connection, ENV['APPNEXUS_MEMBER_ID']) }
+  let(:new_creative) {
+    {
+      "campaign"  => "default campaign",
+      "content"   => "<iframe src='helloword.html'></iframe>",
+      "width"     => "300",
+      "height"    => "250",
+      "template"  =>{ "id" => 7 }
+    }
+  }
+
+  xit 'respects the throttle limit' do
+    # this spec is purposefully disabled as it will create 100 new creatives as fast as possbile to bump up against
+    # the write limits.  Run this spec at your own peril!  Also, running this spec more than once in a row will
+    # bump up against your authorization limit of 10 per 300 seconds
+    expect do
+      10.times do
+        threads = []
+        10.times do
+          threads << Thread.new do
+            creative = creative_service.create(new_creative)
+            puts creative.dbg_info
+          end
+        end
+        threads.map(&:join)
+      end
+    end.to_not raise_error
+  end
+
+  it 'supports a get operation' do
+    expect {
+      creative_service.get("start_element" => 0, "num_elements" => 1)
+    }.to_not raise_error
+  end
+
+  context "creating a new creative" do
+    it 'supports creating a new creative' do
+      creative = creative_service.create(new_creative)
+      expect(creative.width).to eq 300
+      expect(creative.height).to eq 250
+    end
+  end
+
+  context "an existing creative" do
+    let(:existing_creative) { creative_service.create(new_creative) }
+
+    it 'supports changing attributes with the update action' do
+      expect(existing_creative.campaign).to eq "default campaign"
+      existing_creative.update("campaign" => "My Best Campaign Yet")
+      expect(existing_creative.campaign).to eq "My Best Campaign Yet"
+    end
+
+    it 'supports removing the creative' do
+      id = existing_creative.id
+      creative = creative_service.get("id" => id).first
+      expect(creative.id).to eq id
+      existing_creative.delete
+      creative = creative_service.get("id" => id)
+      expect(creative).to be_nil
+    end
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,14 +3,19 @@ Dotenv.load
 
 Bundler.require
 require 'pry'
+require 'logger'
 require_relative "../lib/appnexusapi"
 # load all support files
 #Dir["spec/support/**/*.rb"].each { |f| require_relative "../"+f }
 def connection
+  logger = Logger.new(STDOUT)
+  logger.level = Logger::INFO
+
   AppnexusApi::Connection.new(
     'username' => ENV['APPNEXUS_USERNAME'],
     'password' => ENV['APPNEXUS_PASSWORD'],
-    'uri'      => ENV['APPNEXUS_URI']
+    'uri'      => ENV['APPNEXUS_URI'],
+    'logger'   => logger
   )
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,18 +4,25 @@ Dotenv.load
 Bundler.require
 require 'pry'
 require 'logger'
-require_relative "../lib/appnexusapi"
-# load all support files
-#Dir["spec/support/**/*.rb"].each { |f| require_relative "../"+f }
-def connection
-  logger = Logger.new(STDOUT)
-  logger.level = Logger::INFO
+require_relative '../lib/appnexusapi'
 
+RSpec.configure do |c|
+  c.filter_run_excluding :slow => true
+end
+
+def test_logger
+  return @logger unless @logger.nil?
+  FileUtils.mkdir_p('./log')
+  @logger = Logger.new('./log/test.log')
+  @logger.level = Logger::INFO
+  @logger
+end
+
+def connection
   AppnexusApi::Connection.new(
     'username' => ENV['APPNEXUS_USERNAME'],
     'password' => ENV['APPNEXUS_PASSWORD'],
     'uri'      => ENV['APPNEXUS_URI'],
-    'logger'   => logger
+    'logger'   => test_logger
   )
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,16 @@
+require 'dotenv'
+Dotenv.load
+
+Bundler.require
+require 'pry'
+require_relative "../lib/appnexusapi"
+# load all support files
+#Dir["spec/support/**/*.rb"].each { |f| require_relative "../"+f }
+def connection
+  AppnexusApi::Connection.new(
+    'username' => ENV['APPNEXUS_USERNAME'],
+    'password' => ENV['APPNEXUS_PASSWORD'],
+    'uri'      => ENV['APPNEXUS_URI']
+  )
+end
+


### PR DESCRIPTION
This PR adds in a few tests centered around the creative service.  

This PR changes the behavior of the create and update actions as it now parses the response from the operation and doesn’t trigger another read.  

This PR also will catch the RATE_EXCEEDED error and wait a few seconds before retrying the operation.  