### PR TITLE
Sandbox and production differ

### DIFF
--- a/lib/appnexusapi/connection.rb
+++ b/lib/appnexusapi/connection.rb
@@ -4,8 +4,9 @@ require 'null_logger'
 
 class AppnexusApi::Connection
   RATE_EXCEEDED_DEFAULT_TIMEOUT = 15
-  # Inexplicably, sandbox uses the correct code of 429, while production uses 405?
-  RATE_EXCEEDED_HTTP_CODES = [429, 405]
+  # Inexplicably, sandbox uses the correct code of 429, while production uses 405? so
+  # we just rely on the error message
+  RATE_EXCEEDED_ERROR = "RATE_EXCEEDED".freeze
 
   def initialize(config)
     @config = config
@@ -69,7 +70,7 @@ class AppnexusApi::Connection
           body,
           { 'Authorization' => @token }.merge(headers)
         )
-        break unless RATE_EXCEEDED_HTTP_CODES.include? response.status
+        break unless response.body.fetch('response', {})['error_code'] == RATE_EXCEEDED_ERROR
         wait_time = response.headers['retry-after'] || RATE_EXCEEDED_DEFAULT_TIMEOUT
         log.info("received rate exceeded.  wait time: #{wait_time}s")
         sleep wait_time.to_i

--- a/lib/appnexusapi/connection.rb
+++ b/lib/appnexusapi/connection.rb
@@ -4,7 +4,8 @@ require 'null_logger'
 
 class AppnexusApi::Connection
   RATE_EXCEEDED_DEFAULT_TIMEOUT = 15
-  RATE_EXCEEDED_HTTP_CODE = 429
+  # Inexplicably, sandbox uses the correct code of 429, while production uses 405?
+  RATE_EXCEEDED_HTTP_CODES = [429, 405]
 
   def initialize(config)
     @config = config
@@ -68,7 +69,7 @@ class AppnexusApi::Connection
           body,
           { 'Authorization' => @token }.merge(headers)
         )
-        break unless response.status == RATE_EXCEEDED_HTTP_CODE
+        break unless RATE_EXCEEDED_HTTP_CODES.include? response.status
         wait_time = response.headers['retry-after'] || RATE_EXCEEDED_DEFAULT_TIMEOUT
         log.info("received rate exceeded.  wait time: #{wait_time}s")
         sleep wait_time.to_i

--- a/lib/appnexusapi/version.rb
+++ b/lib/appnexusapi/version.rb
@@ -1,3 +1,3 @@
 module AppnexusApi
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.1.2'.freeze
 end


### PR DESCRIPTION
for some reason Appnexus decided to return a 429 http code in the
sandbox, but return a 405 http code in production for a rate exceeded
error.  Instead of relying on the error code, we'll examine the response
for the RATE_EXCEEDED message and then pull the 'retry-after' value from
the headers