### PR TITLE
Adding in object limit service

### DIFF
--- a/appnexusapi.gemspec
+++ b/appnexusapi.gemspec
@@ -2,11 +2,11 @@
 require File.expand_path('../lib/appnexusapi/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Brandon Aaron"]
-  gem.email         = ["brandon.aaron@gmail.com"]
+  gem.authors       = ["Marlon Moyer", "Josh Scott", "Brandon Aaron"]
+  gem.email         = ["marlon@simpli.fi", "josh@simpli.fi"]
   gem.description   = %q{}
   gem.summary       = %q{Unofficial Ruby API Wrapper for Appnexus}
-  gem.homepage      = "http://simpli.fi"
+  gem.homepage      = "https://github.com/simplifi/appnexusapi"
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")

--- a/lib/appnexusapi/object_limit_resource.rb
+++ b/lib/appnexusapi/object_limit_resource.rb
@@ -1,0 +1,2 @@
+class AppnexusApi::ObjectLimitResource < AppnexusApi::Resource
+end

--- a/lib/appnexusapi/object_limit_service.rb
+++ b/lib/appnexusapi/object_limit_service.rb
@@ -1,0 +1,13 @@
+class AppnexusApi::ObjectLimitService < AppnexusApi::Service
+  def creative_limits
+    get(object_type: 'creative').first
+  end
+
+  def profile_limits
+    get(object_type: 'profile').first
+  end
+
+  def domain_list_limits
+    get(object_type: 'domain_list').first
+  end
+end

--- a/lib/appnexusapi/version.rb
+++ b/lib/appnexusapi/version.rb
@@ -1,3 +1,3 @@
 module AppnexusApi
-  VERSION = '0.1.2'.freeze
+  VERSION = '0.1.3'.freeze
 end

--- a/spec/object_limit_service_spec.rb
+++ b/spec/object_limit_service_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe AppnexusApi::ObjectLimitService do
+  let(:object_limit_service) do
+    AppnexusApi::ObjectLimitService.new(connection)
+  end
+
+  it "returns info about your current creative limits" do
+    creative_limits = object_limit_service.creative_limits.raw_json
+    expect(creative_limits["object_type"]).to eq "creative"
+    expect(creative_limits["limit"].to_i).to be > 0
+  end
+
+  it "returns info about your current profile limits" do
+    profile_limits = object_limit_service.profile_limits.raw_json
+    expect(profile_limits["object_type"]).to eq "profile"
+  end
+
+  it "returns info about your current domain list limits" do
+    domain_list_limits = object_limit_service.domain_list_limits.raw_json
+    expect(domain_list_limits["object_type"]).to eq "domain_list"
+  end
+end
+


### PR DESCRIPTION
object limit service will let us know in advance whether or not we are getting close to hitting the limit of on server objects.