### PR TITLE
Simplify service creation. Minor fixes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,6 @@
 #!/usr/bin/env rake
 require "bundler/gem_tasks"
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+task default: %i[spec]

--- a/appnexusapi.gemspec
+++ b/appnexusapi.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'retriable', '>= 2.0'
 
   gem.add_development_dependency 'bundler', '>= 1.2.0'
+  gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'dotenv'
   gem.add_development_dependency 'pry'

--- a/appnexusapi.gemspec
+++ b/appnexusapi.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'bundler', '>= 1.2.0'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'rspec-its'
   gem.add_development_dependency 'dotenv'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'vcr'

--- a/appnexusapi.gemspec
+++ b/appnexusapi.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = AppnexusApi::VERSION
 
+  gem.required_ruby_version = '>= 2.2'
+
   gem.add_dependency 'faraday', '~> 0.9'
   gem.add_dependency 'faraday_middleware'
   gem.add_dependency 'multi_json'

--- a/lib/appnexusapi/connection.rb
+++ b/lib/appnexusapi/connection.rb
@@ -69,10 +69,11 @@ module AppnexusApi
     private
 
     def run_request(method, route, body, headers)
-      login unless is_authorized?
       response = {}
 
       Retriable.retriable(on: Unauthorized, on_retry: Proc.new { logout }) do
+        login unless is_authorized?
+
         Retriable.retriable(on: RateLimitExceeded, on_retry: RATE_LIMIT_WAITER) do
           begin
             response = @connection.run_request(

--- a/lib/appnexusapi/read_only_service.rb
+++ b/lib/appnexusapi/read_only_service.rb
@@ -1,8 +1,7 @@
 module AppnexusApi
   class ReadOnlyService < Service
-    def initialize(connection)
-      @read_only = true
-      super(connection)
+    def initialize(connection, **opts)
+      super(connection, read_only: true, **opts)
     end
   end
 end

--- a/lib/appnexusapi/service.rb
+++ b/lib/appnexusapi/service.rb
@@ -34,6 +34,20 @@ class AppnexusApi::Service
     responses
   end
 
+  # All returns an enumerator.
+  def all(params = {})
+    Enumerator.new do |y|
+      offset = 0
+      responses = get(params)
+
+      while responses.size > 0
+        responses.each {|x| y << x }
+        offset += responses.size
+        responses = get(params.merge('start_element' => offset))
+      end
+    end
+  end
+
   def create(route_params = {}, body = {})
     check_read_only!
     route = @connection.build_url(uri_suffix, route_params)

--- a/lib/appnexusapi/service.rb
+++ b/lib/appnexusapi/service.rb
@@ -36,15 +36,15 @@ class AppnexusApi::Service
 
   # All returns an enumerator.
   def all(params = {})
-    Enumerator.new do |y|
-      offset = 0
-      responses = get(params)
+    Enumerator.new do |enum|
+      limit  = params.fetch('num_elements', DEFAULT_NUMBER_OF_ELEMENTS).to_i
+      offset = params.fetch('start_element', 0).to_i
 
-      while responses.size > 0
-        responses.each {|x| y << x }
-        offset += responses.size
+      begin
         responses = get(params.merge('start_element' => offset))
-      end
+        responses.each {|res| enum << res }
+        offset += responses.size
+      end until responses.size != limit
     end
   end
 

--- a/lib/appnexusapi/service.rb
+++ b/lib/appnexusapi/service.rb
@@ -1,31 +1,19 @@
 class AppnexusApi::Service
   DEFAULT_NUMBER_OF_ELEMENTS = 100
 
-  def initialize(connection)
-    @connection = connection
-  end
+  attr_reader :name, :plural_name, :uri_name, :plural_uri_name, :uri_suffix
 
-  def name
-    @name ||= begin
+  def initialize(connection, read_only: false, name: nil, plural_name: nil, uri_name: nil, plural_uri_name: nil, uri_suffix: nil)
+    @connection = connection
+    @name = name || begin
       str = self.class.name.split('::').last.sub(/Service\z/, '')
       str.gsub(/(.)([A-Z])/, '\1_\2').downcase
     end
-  end
-
-  def plural_name
-    name + 's'
-  end
-
-  def uri_name
-    name.gsub('_', '-')
-  end
-
-  def plural_uri_name
-    uri_name + 's'
-  end
-
-  def uri_suffix
-    uri_name
+    @plural_name = plural_name || "#{@name}s"
+    @uri_name = uri_name || @name.gsub('_', '-')
+    @plural_uri_name = plural_uri_name || @plural_name.gsub('_', '-')
+    @uri_suffix = uri_suffix || @uri_name
+    @read_only = read_only
   end
 
   def get(params = {})

--- a/lib/appnexusapi/services/ad_server_service.rb
+++ b/lib/appnexusapi/services/ad_server_service.rb
@@ -1,9 +1,5 @@
 class AppnexusApi::AdServerService < AppnexusApi::ReadOnlyService
-  def name
-    "adserver"
-  end
-
-  def uri_suffix
-    "ad-server"
+  def initialize(connection, **opts)
+    super(connection, name: 'adserver', uri_suffix: 'ad-server', **opts)
   end
 end

--- a/lib/appnexusapi/services/bidder_instance_service.rb
+++ b/lib/appnexusapi/services/bidder_instance_service.rb
@@ -1,15 +1,6 @@
 class AppnexusApi::BidderInstanceService < AppnexusApi::Service
-  def initialize(connection, bidder_id)
-    @bidder_id = bidder_id
-    super(connection)
-  end
-
-  def name
-    "instance"
-  end
-
-  def uri_suffix
-    "bidder-instance/#{@bidder_id}"
+  def initialize(connection, bidder_id, **opts)
+    super(connection, name: 'instance', uri_suffix: "bidder-instance/#{bidder_id}", **opts)
   end
 
   def delete(id)

--- a/lib/appnexusapi/services/bidder_profile_service.rb
+++ b/lib/appnexusapi/services/bidder_profile_service.rb
@@ -1,15 +1,6 @@
 class AppnexusApi::BidderProfileService < AppnexusApi::Service
-  def initialize(connection, bidder_id)
-    @bidder_id = bidder_id
-    super(connection)
-  end
-
-  def name
-    "profile"
-  end
-
-  def uri_suffix
-    "profile/#{@bidder_id}"
+  def initialize(connection, bidder_id, **opts)
+    super(connection, name: 'profile', uri_suffix: "profile/#{bidder_id}", **opts)
   end
 
   def delete(id)

--- a/lib/appnexusapi/services/category_service.rb
+++ b/lib/appnexusapi/services/category_service.rb
@@ -1,5 +1,5 @@
 class AppnexusApi::CategoryService < AppnexusApi::ReadOnlyService
-  def plural_name
-    "categories"
+  def initialize(connection, **opts)
+    super(connection, plural_name: 'categories', **opts)
   end
 end

--- a/lib/appnexusapi/services/city_service.rb
+++ b/lib/appnexusapi/services/city_service.rb
@@ -1,0 +1,5 @@
+class AppnexusApi::CityService < AppnexusApi::Service
+  def initialize(conn, **opts)
+    super(conn, plural_name: 'cities', **opts)
+  end
+end

--- a/lib/appnexusapi/services/content_category_service.rb
+++ b/lib/appnexusapi/services/content_category_service.rb
@@ -1,13 +1,5 @@
 class AppnexusApi::ContentCategoryService < AppnexusApi::Service
-  def initialize(connection)
-    super(connection)
-  end
-
-  def plural_name
-    "content_categories"
-  end
-
-  def plural_uri_name
-    "content-categories"
+  def initialize(connection, **opts)
+    super(connection, plural_name: 'content_categories', **opts)
   end
 end

--- a/lib/appnexusapi/services/country_service.rb
+++ b/lib/appnexusapi/services/country_service.rb
@@ -1,0 +1,5 @@
+class AppnexusApi::CountryService < AppnexusApi::Service
+  def initialize(conn, **opts)
+    super(conn, plural_name: 'countries', **opts)
+  end
+end

--- a/lib/appnexusapi/services/creative_template_service.rb
+++ b/lib/appnexusapi/services/creative_template_service.rb
@@ -1,10 +1,6 @@
 class AppnexusApi::CreativeTemplateService < AppnexusApi::Service
-  def name
-    "template"
-  end
-
-  def uri_suffix
-    name
+  def initialize(connection, **opts)
+    super(connection, name: 'template',  uri_suffix: 'template', **opts)
   end
 
   def delete(id)

--- a/lib/appnexusapi/services/insertion_order_service.rb
+++ b/lib/appnexusapi/services/insertion_order_service.rb
@@ -1,0 +1,2 @@
+class AppnexusApi::InsertionOrderService < AppnexusApi::Service
+end

--- a/lib/appnexusapi/services/inventory_list_item_service.rb
+++ b/lib/appnexusapi/services/inventory_list_item_service.rb
@@ -1,0 +1,5 @@
+class AppnexusApi::InventoryListItemService < AppnexusApi::Service
+  def initialize(conn, inventory_list_id, **opts)
+    super(conn, uri_suffix: "inventory-list/#{inventory_list_id}/item", **opts)
+  end
+end

--- a/lib/appnexusapi/services/inventory_list_service.rb
+++ b/lib/appnexusapi/services/inventory_list_service.rb
@@ -1,0 +1,2 @@
+class AppnexusApi::InventoryListService < AppnexusApi::Service
+end

--- a/lib/appnexusapi/services/log_level_data_service.rb
+++ b/lib/appnexusapi/services/log_level_data_service.rb
@@ -12,18 +12,14 @@ module AppnexusApi
       end
     }.freeze
 
-    def initialize(connection, options = {})
-      @downloaded_files_path = options[:downloaded_files_path] || '.'
-      @siphon_name = options[:siphon_name] || DEFAULT_FEED
-      super(connection)
+    def initialize(connection, downloaded_files_path: '.', siphon_name: DEFAULT_FEED, **opts)
+      @downloaded_files_path = downloaded_files_path
+      @siphon_name = siphon_name
+      super(connection, uri_name: 'siphon', **opts)
     end
 
     def download_new_files_since(time = nil)
       since(time).map { |siphon| download_resource(siphon) }
-    end
-
-    def uri_name
-      'siphon'
     end
 
     def since(time = nil)

--- a/lib/appnexusapi/services/operating_system_extended_service.rb
+++ b/lib/appnexusapi/services/operating_system_extended_service.rb
@@ -1,5 +1,5 @@
 class AppnexusApi::OperatingSystemExtendedService < AppnexusApi::ReadOnlyService
-  def plural_name
-    'operating-systems-extended'
+  def initialize(connection, **opts)
+    super(connection, plural_name: 'operating-systems-extended', **opts)
   end
 end

--- a/lib/appnexusapi/services/postal_code_service.rb
+++ b/lib/appnexusapi/services/postal_code_service.rb
@@ -1,0 +1,2 @@
+class AppnexusApi::PostalCodeService < AppnexusApi::Service
+end

--- a/lib/appnexusapi/services/region_service.rb
+++ b/lib/appnexusapi/services/region_service.rb
@@ -1,0 +1,2 @@
+class AppnexusApi::RegionService < AppnexusApi::Service
+end

--- a/lib/appnexusapi/services/segment_service.rb
+++ b/lib/appnexusapi/services/segment_service.rb
@@ -1,10 +1,5 @@
 class AppnexusApi::SegmentService < AppnexusApi::Service
-  def initialize(connection, member_id)
-    @member_id = member_id
-    super(connection)
-  end
-
-  def uri_suffix
-    "#{super}/#{@member_id}"
+  def initialize(connection, member_id, **opts)
+    super(connection, uri_suffix: "segments/#{member_id}", **opts)
   end
 end

--- a/lib/appnexusapi/services/segment_service.rb
+++ b/lib/appnexusapi/services/segment_service.rb
@@ -1,5 +1,2 @@
 class AppnexusApi::SegmentService < AppnexusApi::Service
-  def initialize(connection, member_id, **opts)
-    super(connection, uri_suffix: "segments/#{member_id}", **opts)
-  end
 end

--- a/lib/appnexusapi/services/tiny_tag_service.rb
+++ b/lib/appnexusapi/services/tiny_tag_service.rb
@@ -1,14 +1,5 @@
 class AppnexusApi::TinyTagService < AppnexusApi::Service
-  def initialize(connection, member_id)
-    @member_id = member_id
-    super(connection)
-  end
-
-  def name
-    "tinytag"
-  end
-
-  def uri_suffix
-    "tt/#{@member_id}"
+  def initialize(connection, member_id, **opts)
+    super(connection, name: 'tinytag', uri_suffix: "tt/#{member_id}", **opts)
   end
 end

--- a/lib/appnexusapi/version.rb
+++ b/lib/appnexusapi/version.rb
@@ -1,3 +1,3 @@
 module AppnexusApi
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.2.0'.freeze
 end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -19,7 +19,7 @@ describe AppnexusApi::Connection do
     it 'returns data from expiration' do
       #stub to raise error the first time and then return []
       counter = 0
-      expect(subject).to receive(:login)
+      expect(subject).to receive(:login).twice
       expect(subject.connection).to receive(:run_request).twice do |arg|
         counter += 1
         raise AppnexusApi::Unauthorized.new if counter == 1

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -39,7 +39,7 @@ describe AppnexusApi::Connection do
       end
 
       before do
-        described_class.const_set('RATE_EXCEEDED_DEFAULT_TIMEOUT', 0)
+        stub_const("#{described_class}::RATE_EXCEEDED_DEFAULT_TIMEOUT", 0)
       end
 
       it 'retries 3 times' do

--- a/spec/fixtures/vcr/insertion_order_service_get.yml
+++ b/spec/fixtures/vcr/insertion_order_service_get.yml
@@ -1,0 +1,93 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api-test.appnexus.com/auth
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"username":"<APPNEXUS_USERNAME>","password":"<APPNEXUS_PASSWORD>"}}'
+    headers:
+      User-Agent:
+      - Faraday v0.11.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0;no-cache
+      Content-Length:
+      - '699'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Feb 2017 12:58:14 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Apache
+      Set-Cookie:
+      - HBFAPI_SESSID=hbapi%3A171678%3A589b15e747998%3Anym2; Path=/
+      X-Route:
+      - "/auth"
+      X-Route-Time:
+      - '1382'
+    body:
+      encoding: UTF-8
+      string: '{"response":{"status":"OK","token":"hbapi:171678:589b15e747998:nym2","dbg_info":{"instance":"01.hbapi.test104169.nym2","slave_hit":false,"db":"master","parent_dbg_info":{"instance":"01.api.test104169.nym2","slave_hit":false,"db":"master","awesomesauce_cache_used":false,"count_cache_used":false,"uuid":"610e58b4-2bcc-5d35-8698-aa06e3019952","warnings":[],"time":793.51305961609,"start_microtime":1486558694.1659,"version":"1.17","output_term":"not_found"},"awesomesauce_cache_used":false,"count_cache_used":false,"uuid":"b5c103e0-caa6-563c-ae94-190899fd7ea0","warnings":[],"time":1369.6370124817,"start_microtime":1486558694.1406,"version":"1.17.202","slave_lag":1040228,"output_term":"not_found"}}}'
+    http_version:
+  recorded_at: Wed, 08 Feb 2017 12:58:13 GMT
+- request:
+    method: get
+    uri: https://api-test.appnexus.com/insertion-order?num_elements=1&start_element=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.11.0
+      Authorization:
+      - hbapi:171678:589b15e747998:nym2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '3464'
+      Content-Type:
+      - application/json
+      X-Count-Read:
+      - user:5,member:3,serviceHostUser:1,serviceHostMember:1,hostUser:1,hostMember:1,ip:0
+      X-Count-Write:
+      - user:0,member:0,serviceHostUser:0,serviceHostMember:0,hostUser:0,hostMember:0,ip:0
+      X-Ratelimit-Read:
+      - '1000'
+      X-Ratelimit-Service:
+      - 1000-Default
+      X-Ratelimit-System:
+      - 1000-Default
+      X-Ratelimit-Write:
+      - '1000'
+      X-Route:
+      - "/insertion-order"
+      X-Route-Time:
+      - '68'
+    body:
+      encoding: UTF-8
+      string: '{"response":{"status":"OK","count":1,"start_element":0,"num_elements":100,"insertion-orders":[{"id":1201,"name":"MyIO","code":"18b89c77-602f-46ba-aaf9-a70b4cef4ff9","state":"active","budget_intervals":[{"id":684,"start_date":"2018-10-10 00:00:00"}]}]}}'
+    http_version:
+  recorded_at: Wed, 08 Feb 2017 12:58:14 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/inventory_list_item_service_get.yml
+++ b/spec/fixtures/vcr/inventory_list_item_service_get.yml
@@ -1,0 +1,94 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api-test.appnexus.com/auth
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"username":"<APPNEXUS_USERNAME>","password":"<APPNEXUS_PASSWORD>"}}'
+    headers:
+      User-Agent:
+      - Faraday v0.11.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0;no-cache
+      Content-Length:
+      - '699'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Feb 2017 12:58:14 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Apache
+      Set-Cookie:
+      - HBFAPI_SESSID=hbapi%3A171678%3A589b15e747998%3Anym2; Path=/
+      X-Route:
+      - "/auth"
+      X-Route-Time:
+      - '1382'
+    body:
+      encoding: UTF-8
+      string: '{"response":{"status":"OK","token":"hbapi:171678:589b15e747998:nym2","dbg_info":{"instance":"01.hbapi.test104169.nym2","slave_hit":false,"db":"master","parent_dbg_info":{"instance":"01.api.test104169.nym2","slave_hit":false,"db":"master","awesomesauce_cache_used":false,"count_cache_used":false,"uuid":"610e58b4-2bcc-5d35-8698-aa06e3019952","warnings":[],"time":793.51305961609,"start_microtime":1486558694.1659,"version":"1.17","output_term":"not_found"},"awesomesauce_cache_used":false,"count_cache_used":false,"uuid":"b5c103e0-caa6-563c-ae94-190899fd7ea0","warnings":[],"time":1369.6370124817,"start_microtime":1486558694.1406,"version":"1.17.202","slave_lag":1040228,"output_term":"not_found"}}}'
+    http_version:
+  recorded_at: Wed, 08 Feb 2017 12:58:13 GMT
+- request:
+    method: get
+    uri: https://api-test.appnexus.com/inventory-list/33/item?num_elements=1&start_element=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.11.0
+      Authorization:
+      - hbapi:171678:589b15e747998:nym2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '3464'
+      Content-Type:
+      - application/json
+      X-Count-Read:
+      - user:5,member:3,serviceHostUser:1,serviceHostMember:1,hostUser:1,hostMember:1,ip:0
+      X-Count-Write:
+      - user:0,member:0,serviceHostUser:0,serviceHostMember:0,hostUser:0,hostMember:0,ip:0
+      X-Ratelimit-Read:
+      - '1000'
+      X-Ratelimit-Service:
+      - 1000-Default
+      X-Ratelimit-System:
+      - 1000-Default
+      X-Ratelimit-Write:
+      - '1000'
+      X-Route:
+      - "/inventory-list/33/item"
+      X-Route-Time:
+      - '68'
+    body:
+      encoding: UTF-8
+      string: '{"response":{"status":"OK","count":1,"start_element":0,"num_elements":100,"inventory-list-items":[{"id":1,"audit_status":"rejected","app_name":null,"inventory_url":"bad-domain.com","include_children":false,"is_supported":true,"rejection_reason":"Violence"}]}}'
+    http_version:
+  recorded_at: Wed, 08 Feb 2017 12:58:14 GMT
+recorded_with: VCR 3.0.3
+

--- a/spec/fixtures/vcr/inventory_list_service_get.yml
+++ b/spec/fixtures/vcr/inventory_list_service_get.yml
@@ -1,0 +1,94 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api-test.appnexus.com/auth
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"username":"<APPNEXUS_USERNAME>","password":"<APPNEXUS_PASSWORD>"}}'
+    headers:
+      User-Agent:
+      - Faraday v0.11.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0;no-cache
+      Content-Length:
+      - '699'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Feb 2017 12:58:14 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Apache
+      Set-Cookie:
+      - HBFAPI_SESSID=hbapi%3A171678%3A589b15e747998%3Anym2; Path=/
+      X-Route:
+      - "/auth"
+      X-Route-Time:
+      - '1382'
+    body:
+      encoding: UTF-8
+      string: '{"response":{"status":"OK","token":"hbapi:171678:589b15e747998:nym2","dbg_info":{"instance":"01.hbapi.test104169.nym2","slave_hit":false,"db":"master","parent_dbg_info":{"instance":"01.api.test104169.nym2","slave_hit":false,"db":"master","awesomesauce_cache_used":false,"count_cache_used":false,"uuid":"610e58b4-2bcc-5d35-8698-aa06e3019952","warnings":[],"time":793.51305961609,"start_microtime":1486558694.1659,"version":"1.17","output_term":"not_found"},"awesomesauce_cache_used":false,"count_cache_used":false,"uuid":"b5c103e0-caa6-563c-ae94-190899fd7ea0","warnings":[],"time":1369.6370124817,"start_microtime":1486558694.1406,"version":"1.17.202","slave_lag":1040228,"output_term":"not_found"}}}'
+    http_version:
+  recorded_at: Wed, 08 Feb 2017 12:58:13 GMT
+- request:
+    method: get
+    uri: https://api-test.appnexus.com/inventory-list?num_elements=1&start_element=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.11.0
+      Authorization:
+      - hbapi:171678:589b15e747998:nym2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '3464'
+      Content-Type:
+      - application/json
+      X-Count-Read:
+      - user:5,member:3,serviceHostUser:1,serviceHostMember:1,hostUser:1,hostMember:1,ip:0
+      X-Count-Write:
+      - user:0,member:0,serviceHostUser:0,serviceHostMember:0,hostUser:0,hostMember:0,ip:0
+      X-Ratelimit-Read:
+      - '1000'
+      X-Ratelimit-Service:
+      - 1000-Default
+      X-Ratelimit-System:
+      - 1000-Default
+      X-Ratelimit-Write:
+      - '1000'
+      X-Route:
+      - "/inventory-list"
+      X-Route-Time:
+      - '68'
+    body:
+      encoding: UTF-8
+      string: '{"response":{"status":"OK","count":1,"start_element":0,"num_elements":100,"inventory-lists":[{"id":3901,"name":"XYZ Whitelist"}]}}'
+    http_version:
+  recorded_at: Wed, 08 Feb 2017 12:58:14 GMT
+recorded_with: VCR 3.0.3
+

--- a/spec/fixtures/vcr/segment_service_get.yml
+++ b/spec/fixtures/vcr/segment_service_get.yml
@@ -1,0 +1,93 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api-test.appnexus.com/auth
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"username":"<APPNEXUS_USERNAME>","password":"<APPNEXUS_PASSWORD>"}}'
+    headers:
+      User-Agent:
+      - Faraday v0.11.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0;no-cache
+      Content-Length:
+      - '699'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Feb 2017 12:58:14 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Apache
+      Set-Cookie:
+      - HBFAPI_SESSID=hbapi%3A171678%3A589b15e747998%3Anym2; Path=/
+      X-Route:
+      - "/auth"
+      X-Route-Time:
+      - '1382'
+    body:
+      encoding: UTF-8
+      string: '{"response":{"status":"OK","token":"hbapi:171678:589b15e747998:nym2","dbg_info":{"instance":"01.hbapi.test104169.nym2","slave_hit":false,"db":"master","parent_dbg_info":{"instance":"01.api.test104169.nym2","slave_hit":false,"db":"master","awesomesauce_cache_used":false,"count_cache_used":false,"uuid":"610e58b4-2bcc-5d35-8698-aa06e3019952","warnings":[],"time":793.51305961609,"start_microtime":1486558694.1659,"version":"1.17","output_term":"not_found"},"awesomesauce_cache_used":false,"count_cache_used":false,"uuid":"b5c103e0-caa6-563c-ae94-190899fd7ea0","warnings":[],"time":1369.6370124817,"start_microtime":1486558694.1406,"version":"1.17.202","slave_lag":1040228,"output_term":"not_found"}}}'
+    http_version:
+  recorded_at: Wed, 08 Feb 2017 12:58:13 GMT
+- request:
+    method: get
+    uri: https://api-test.appnexus.com/segment?num_elements=100&start_element=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.11.0
+      Authorization:
+      - hbapi:171678:589b15e747998:nym2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '3464'
+      Content-Type:
+      - application/json
+      X-Count-Read:
+      - user:5,member:3,serviceHostUser:1,serviceHostMember:1,hostUser:1,hostMember:1,ip:0
+      X-Count-Write:
+      - user:0,member:0,serviceHostUser:0,serviceHostMember:0,hostUser:0,hostMember:0,ip:0
+      X-Ratelimit-Read:
+      - '1000'
+      X-Ratelimit-Service:
+      - 1000-Default
+      X-Ratelimit-System:
+      - 1000-Default
+      X-Ratelimit-Write:
+      - '1000'
+      X-Route:
+      - "/segment"
+      X-Route-Time:
+      - '68'
+    body:
+      encoding: UTF-8
+      string: '{"response":{"status":"OK","segments":[{"id":11836,"code":null,"state":"active","short_name":"March 10","description":null,"member_id":185,"category":null,"price":"0","expire_minutes":null,"enable_rm_piggyback":true,"max_usersync_pixels":0,"last_modified":"2010-03-10 23:23:48","provider":null,"parent_segment_id":null,"advertiser_id":51,"piggyback_pixels":null}]}}'
+    http_version:
+  recorded_at: Wed, 08 Feb 2017 12:58:14 GMT
+recorded_with: VCR 3.0.3

--- a/spec/integration/insertion_order_service_spec.rb
+++ b/spec/integration/insertion_order_service_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe AppnexusApi::InsertionOrderService do
+  subject { described_class.new(connection) }
+
+  its(:name) { is_expected.to eq('insertion_order') }
+  its(:plural_name) { is_expected.to eq('insertion_orders') }
+  its(:uri_name) { is_expected.to eq('insertion-order') }
+  its(:plural_uri_name) { is_expected.to eq('insertion-orders') }
+  its(:uri_suffix) { is_expected.to eq('insertion-order') }
+
+  it 'supports get operation' do
+    VCR.use_cassette('insertion_order_service_get') do
+      resp = subject.get('start_element' => 0, 'num_elements' => 1)
+      expect(resp.size).to eq(1)
+      expect(resp.first.to_h).to include("id" => 1201, "name" => "MyIO")
+    end
+  end
+end

--- a/spec/integration/inventory_list_item_service_spec.rb
+++ b/spec/integration/inventory_list_item_service_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe AppnexusApi::InventoryListItemService do
+  subject { described_class.new(connection, 33) }
+
+  its(:name) { is_expected.to eq('inventory_list_item') }
+  its(:plural_name) { is_expected.to eq('inventory_list_items') }
+  its(:uri_name) { is_expected.to eq('inventory-list-item') }
+  its(:plural_uri_name) { is_expected.to eq('inventory-list-items') }
+  its(:uri_suffix) { is_expected.to eq('inventory-list/33/item') }
+
+  it 'supports get operation' do
+    VCR.use_cassette('inventory_list_item_service_get') do
+      resp = subject.get('start_element' => 0, 'num_elements' => 1)
+      expect(resp.size).to eq(1)
+      expect(resp.first.to_h).to include("id" => 1, "inventory_url" => "bad-domain.com")
+    end
+  end
+end

--- a/spec/integration/inventory_list_service_spec.rb
+++ b/spec/integration/inventory_list_service_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe AppnexusApi::InventoryListService do
+  subject { described_class.new(connection) }
+
+  its(:name) { is_expected.to eq('inventory_list') }
+  its(:plural_name) { is_expected.to eq('inventory_lists') }
+  its(:uri_name) { is_expected.to eq('inventory-list') }
+  its(:plural_uri_name) { is_expected.to eq('inventory-lists') }
+  its(:uri_suffix) { is_expected.to eq('inventory-list') }
+
+  it 'supports get operation' do
+    VCR.use_cassette('inventory_list_service_get') do
+      resp = subject.get('start_element' => 0, 'num_elements' => 1)
+      expect(resp.size).to eq(1)
+      expect(resp.first.to_h).to include("id" => 3901, "name" => "XYZ Whitelist")
+    end
+  end
+end

--- a/spec/integration/log_level_data_service_spec.rb
+++ b/spec/integration/log_level_data_service_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe AppnexusApi::LogLevelDataService do
   after(:each) do
-    system('rm standard_feed_2017_02_13_00_0.gz')
+    FileUtils.rm_f 'standard_feed_2017_02_13_00_0.gz'
   end
 
   it 'downloads new files' do

--- a/spec/integration/placement_spec.rb
+++ b/spec/integration/placement_spec.rb
@@ -18,8 +18,8 @@ describe AppnexusApi::PlacementService do
 
       # grab the default placement
       default_placement = placement_service.get(id: default_site.placements.first["id"]).first
-      default_placement.name.should  == "[Publisher Name] - Default"
-      default_placement.state.should == "active"
+      expect(default_placement.name).to  eq("[Publisher Name] - Default")
+      expect(default_placement.state).to eq("active")
 
       default_site.delete
       publisher.delete

--- a/spec/integration/profile_spec.rb
+++ b/spec/integration/profile_spec.rb
@@ -20,7 +20,7 @@ describe AppnexusApi::ProfileService do
       expect(profile.country_targets).to eq([{ "id"=>233,"code"=>"US", "name"=>"United States", "active"=>true }])
 
       new_line_item = line_item_service.create(advertiser_url_params, line_item_params.merge(profile_id: profile.id))
-      new_line_item.profile_id.should == profile.id
+      expect(new_line_item.profile_id).to eq(profile.id)
 
       new_line_item.delete({ "advertiser_id" => advertiser_id })
       advertiser.delete

--- a/spec/integration/segment_service_spec.rb
+++ b/spec/integration/segment_service_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe AppnexusApi::SegmentService do
+  subject { described_class.new(connection) }
+
+  its(:name) { is_expected.to eq('segment') }
+  its(:plural_name) { is_expected.to eq('segments') }
+  its(:uri_name) { is_expected.to eq('segment') }
+  its(:plural_uri_name) { is_expected.to eq('segments') }
+  its(:uri_suffix) { is_expected.to eq('segment') }
+
+  it 'supports get operation' do
+    VCR.use_cassette('segment_service_get') do
+      resp = subject.get()
+      expect(resp.size).to eq(1)
+      expect(resp.first.to_h).to include("id" => 11836, "short_name" => "March 10")
+    end
+  end
+end

--- a/spec/integration/site_spec.rb
+++ b/spec/integration/site_spec.rb
@@ -19,11 +19,11 @@ describe AppnexusApi::SiteService do
       }
 
       new_site = site_service.create(new_site_url_params, new_site_params)
-      new_site.name.should == "Site Name"
-      new_site.code.should == site_code
-      new_site.url.should  == "http://www.example.com"
-      new_site.intended_audience.should == "general"
-      new_site.audited.should == true
+      expect(new_site.name).to eq("Site Name")
+      expect(new_site.code).to eq(site_code)
+      expect(new_site.url).to  eq("http://www.example.com")
+      expect(new_site.intended_audience).to eq("general")
+      expect(new_site.audited).to eq(true)
 
       new_site.delete
       publisher.delete

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'pry'
 require 'logger'
 require 'vcr'
 require 'webmock'
+require 'rspec/its'
 require_relative '../lib/appnexusapi'
 Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 


### PR DESCRIPTION
This PR avoids a few allocations by 'calculating' and memoizing names & paths in the constructor. It makes it simpler to create new/custom service abstractions.  